### PR TITLE
feat: Add scheduling for NaverSeries recent novels and Transform batch processing

### DIFF
--- a/docs/optimization/scheduling-overview.md
+++ b/docs/optimization/scheduling-overview.md
@@ -18,23 +18,25 @@
 
 | 시간 | 작업 | 플랫폼 | 파일 |
 |------|------|--------|------|
+| 02:00 | 신작 웹소설 수집 | 네이버 시리즈 | `NaverSeriesSchedulingService` |
 | 02:00 | 전체 요일 웹툰 수집 | 네이버 웹툰 | `NaverWebtoonSchedulingService` |
 | 04:00 | 신규 콘텐츠 수집 (최근 7일) | TMDB | `TmdbSchedulingService` |
+| 06:00 | raw_items 배치 변환 | Transform | `TransformSchedulingService` |
 
 ### 매주 실행
 
 | 요일 | 시간 | 작업 | 플랫폼 | 파일 |
 |------|------|------|--------|------|
 | 일요일 | 03:00 | 완결 웹툰 수집 | 네이버 웹툰 | `NaverWebtoonSchedulingService` |
+| 일요일 | 03:00 | 완결 웹소설 대규모 수집 | 네이버 시리즈 | `NaverSeriesSchedulingService` |
 | 일요일 | 05:00 | 과거 콘텐츠 최신화 (연도별) | TMDB | `TmdbSchedulingService` |
-| 화요일 | 02:00 | 완결 웹소설 수집 | 네이버 시리즈 | `NaverSeriesSchedulingService` |
+| 일요일 | 07:00 | raw_items 주간 대규모 변환 | Transform | `TransformSchedulingService` |
 | 목요일 | 03:00 | 전체 게임 수집 | Steam | `SteamSchedulingService` |
 
 ### 매월 실행
 
 | 날짜 | 시간 | 작업 | 플랫폼 | 파일 |
 |------|------|------|--------|------|
-| 1일 | 03:00 | 전체 완결작품 대규모 수집 | 네이버 시리즈 | `NaverSeriesSchedulingService` |
 | 15일 | 04:00 | 기존 게임 정보 업데이트 | Steam | `SteamSchedulingService` |
 
 ---
@@ -44,14 +46,16 @@
 ```
 00:00 ┃
 01:00 ┃
-02:00 ┃ ▶ 네이버 웹툰 (매일)
-      ┃ ▶ 네이버 시리즈 완결작 (화)
+02:00 ┃ ▶ 네이버 시리즈 신작 (매일)
+      ┃ ▶ 네이버 웹툰 요일별 (매일)
 03:00 ┃ ▶ 네이버 웹툰 완결작 (일)
+      ┃ ▶ 네이버 시리즈 완결작 (일)
       ┃ ▶ Steam 전체 수집 (목)
-      ┃ ▶ 네이버 시리즈 대규모 (매월 1일)
 04:00 ┃ ▶ TMDB 신규 콘텐츠 (매일)
       ┃ ▶ Steam 업데이트 (매월 15일)
 05:00 ┃ ▶ TMDB 과거 데이터 (일)
+06:00 ┃ ▶ Transform 배치 변환 (매일)
+07:00 ┃ ▶ Transform 대규모 변환 (일)
 ```
 
 **💡 시간대 분산 이유:**
@@ -106,17 +110,18 @@ Week 1: 2025년 → Week 2: 2024년 → ... → Week N: 1980년 → 다시 2025�
 **경로:** `src/main/java/com/example/AOD/contents/Novel/NaverSeriesNovel/NaverSeriesSchedulingService.java`
 
 ```java
-@Scheduled(cron = "0 0 2 * * TUE")  // 화요일 02:00
-public void collectNaverSeriesWeekly()
+@Scheduled(cron = "0 0 2 * * *")  // 매일 02:00
+public void collectRecentNovelsDaily()
 
-@Scheduled(cron = "0 0 3 1 * *")  // 매월 1일 03:00
-public void collectAllCategoriesMonthly()
+@Scheduled(cron = "0 0 3 * * SUN")  // 일요일 03:00
+public void collectCompletedNovelsWeekly()
 ```
 
 **수집 데이터:**
-- 주간: 완결작품 카테고리 (10페이지, ~200개 작품)
-- 월간: 전체 완결작품 (100페이지, ~2000개 작품)
-- URL: `https://series.naver.com/novel/categoryProductList.series?categoryTypeCode=all`
+- 매일: 신작 웹소설 (3페이지, ~60개 작품)
+  - URL: `https://series.naver.com/novel/recentList.series`
+- 주간: 완결작품 대규모 수집 (50페이지, ~1000개 작품)
+  - URL: `https://series.naver.com/novel/categoryProductList.series?categoryTypeCode=all`
 
 ---
 
@@ -134,6 +139,34 @@ public void updateExistingGamesMonthly()
 **수집 데이터:**
 - 주간: 신규 게임 추가 (1000개씩 자동 분할)
 - 월간: 기존 게임 정보 업데이트 (가격, 리뷰 등)
+
+---
+
+### 5. **TransformSchedulingService**
+**경로:** `src/main/java/com/example/AOD/ingest/TransformSchedulingService.java`
+
+```java
+@Scheduled(cron = "0 0 6 * * *")  // 매일 06:00
+public void transformRawItemsDaily()
+
+@Scheduled(cron = "0 0 7 * * SUN")  // 일요일 07:00
+public void transformRawItemsWeekly()
+```
+
+**처리 데이터:**
+- 매일: 미처리 raw_items 배치 변환 (100개씩)
+  - 모든 크롤러의 크롤링 완료 후 실행
+  - 미처리 데이터가 없을 때까지 반복
+- 주간: 대규모 배치 변환 (200개씩)
+  - 주간 누적된 데이터 일괄 처리
+  - 더 큰 배치 크기로 빠른 처리
+
+**변환 프로세스:**
+1. raw_items 테이블에서 미처리 데이터 조회
+2. 플랫폼/도메인별 YAML 규칙 로드
+3. TransformEngine으로 변환 (master/platform/domain)
+4. UpsertService로 contents/platform_data 저장
+5. transform_runs 테이블에 이력 기록
 
 ---
 
@@ -230,4 +263,9 @@ public CompletableFuture<Integer> crawlAsync() {
 
 ---
 
-**최종 업데이트:** 2025-11-17
+**최종 업데이트:** 2025-12-03
+
+**주요 변경사항:**
+- 네이버 시리즈: 신작 매일 수집 추가 (recentList.series)
+- 네이버 시리즈: 완결작 주간 수집으로 변경 (화요일 → 일요일)
+- Transform 스케줄러: raw_items 자동 변환 추가 (매일 06:00, 주간 07:00)

--- a/src/main/java/com/example/AOD/contents/Novel/NaverSeriesNovel/NaverSeriesCrawler.java
+++ b/src/main/java/com/example/AOD/contents/Novel/NaverSeriesNovel/NaverSeriesCrawler.java
@@ -29,6 +29,28 @@ public class NaverSeriesCrawler {
         this.collector = collector;
     }
 
+    /**
+     * 신작 목록 크롤링 (recentList.series)
+     * @param cookieString 쿠키 (선택)
+     * @param maxPages 최대 페이지 수 (0이면 무제한)
+     * @return 저장된 작품 수
+     */
+    public int crawlRecentNovels(String cookieString, int maxPages) throws Exception {
+        String baseUrl = "https://series.naver.com/novel/recentList.series?page=";
+        return crawlToRaw(baseUrl, cookieString, maxPages);
+    }
+
+    /**
+     * 완결 작품 크롤링 (categoryProductList.series)
+     * @param cookieString 쿠키 (선택)
+     * @param maxPages 최대 페이지 수 (0이면 무제한)
+     * @return 저장된 작품 수
+     */
+    public int crawlCompletedNovels(String cookieString, int maxPages) throws Exception {
+        String baseUrl = "https://series.naver.com/novel/categoryProductList.series?categoryTypeCode=all&page=";
+        return crawlToRaw(baseUrl, cookieString, maxPages);
+    }
+
     public int crawlToRaw(String baseListUrl, String cookieString, int maxPages) throws Exception {
         int saved = 0;
         int page = 1;

--- a/src/main/java/com/example/AOD/contents/Novel/NaverSeriesNovel/NaverSeriesSchedulingService.java
+++ b/src/main/java/com/example/AOD/contents/Novel/NaverSeriesNovel/NaverSeriesSchedulingService.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Service;
 
 /**
  * 네이버 시리즈 정기 크롤링 스케줄러
- * - crawlerTaskExecutor 스레드풀 사용
- * - 비동기 실행으로 스케줄러 스레드 블로킹 방지
+ * - 신작: 매일 정기 수집 (recentList.series)
+ * - 완결작: 주 1회 대규모 수집 (categoryProductList.series)
  */
 @Slf4j
 @Service
@@ -18,46 +18,44 @@ public class NaverSeriesSchedulingService {
     private final NaverSeriesCrawler naverSeriesCrawler;
 
     /**
-     * 매주 화요일 새벽 2시에 네이버 시리즈 완결작품 수집
-     * - 웹소설은 변화가 느리므로 주 1회 업데이트
-     * - 완결작품 카테고리 페이지 기준
+     * 매일 새벽 2시에 네이버 시리즈 신작 수집
+     * - 신작은 자주 업데이트되므로 매일 크롤링
+     * - recentList.series 페이지 기준 (최신 3페이지, 약 60개)
      */
-    @Scheduled(cron = "0 0 2 * * TUE") // 매주 화요일 새벽 2시
-    public void collectNaverSeriesWeekly() {
-        log.info("🚀 [정기 스케줄] 네이버 시리즈 완결작품 크롤링 시작");
+    @Scheduled(cron = "0 0 2 * * *") // 매일 새벽 2시
+    public void collectRecentNovelsDaily() {
+        log.info("🚀 [정기 스케줄] 네이버 시리즈 신작 크롤링 시작");
         
         try {
-            String baseUrl = "https://series.naver.com/novel/categoryProductList.series?categoryTypeCode=all&page=";
             String cookie = ""; // 쿠키 필요 시 설정
-            int pages = 10; // 완결작품 10페이지 (페이지당 20개, 총 200개)
+            int pages = 3; // 신작 최신 3페이지 (페이지당 20개, 총 60개)
             
-            int saved = naverSeriesCrawler.crawlToRaw(baseUrl, cookie, pages);
+            int saved = naverSeriesCrawler.crawlRecentNovels(cookie, pages);
             
-            log.info("✅ [정기 스케줄] 네이버 시리즈 완결작품 크롤링 완료: {}개 저장", saved);
+            log.info("✅ [정기 스케줄] 네이버 시리즈 신작 크롤링 완료: {}개 저장", saved);
         } catch (Exception e) {
-            log.error("❌ [정기 스케줄] 네이버 시리즈 완결작품 크롤링 실패: {}", e.getMessage(), e);
+            log.error("❌ [정기 스케줄] 네이버 시리즈 신작 크롤링 실패: {}", e.getMessage(), e);
         }
     }
 
     /**
-     * 매월 1일 새벽 3시에 전체 완결작품 대규모 수집
-     * - 월 1회 대규모 수집
-     * - 최대 100페이지 (2000개 작품)
+     * 매주 일요일 새벽 3시에 전체 완결작품 대규모 수집
+     * - 완결작은 변화가 느리므로 주 1회 업데이트
+     * - 최대 50페이지 (1000개 작품)
      */
-    @Scheduled(cron = "0 0 3 1 * *") // 매월 1일 새벽 3시
-    public void collectAllCategoriesMonthly() {
-        log.info("🚀 [정기 스케줄] 네이버 시리즈 전체 완결작품 대규모 크롤링 시작");
+    @Scheduled(cron = "0 0 3 * * SUN") // 매주 일요일 새벽 3시
+    public void collectCompletedNovelsWeekly() {
+        log.info("🚀 [정기 스케줄] 네이버 시리즈 완결작품 대규모 크롤링 시작");
         
         try {
-            String baseUrl = "https://series.naver.com/novel/categoryProductList.series?categoryTypeCode=all&page=";
             String cookie = "";
-            int pages = 100; // 대규모 수집 (2000개 작품)
+            int pages = 50; // 완결작품 50페이지 (페이지당 20개, 총 1000개)
             
-            int saved = naverSeriesCrawler.crawlToRaw(baseUrl, cookie, pages);
+            int saved = naverSeriesCrawler.crawlCompletedNovels(cookie, pages);
             
-            log.info("✅ [정기 스케줄] 네이버 시리즈 대규모 크롤링 완료: {}개 저장", saved);
+            log.info("✅ [정기 스케줄] 네이버 시리즈 완결작품 크롤링 완료: {}개 저장", saved);
         } catch (Exception e) {
-            log.error("❌ [정기 스케줄] 네이버 시리즈 대규모 크롤링 실패: {}", e.getMessage(), e);
+            log.error("❌ [정기 스케줄] 네이버 시리즈 완결작품 크롤링 실패: {}", e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/example/AOD/ingest/TransformSchedulingService.java
+++ b/src/main/java/com/example/AOD/ingest/TransformSchedulingService.java
@@ -1,0 +1,89 @@
+package com.example.AOD.ingest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Transform 정기 스케줄러
+ * - 크롤링된 raw_items를 정기적으로 변환하여 contents로 upsert
+ * - 처리되지 않은 데이터를 배치로 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TransformSchedulingService {
+
+    private final BatchTransformService batchTransformService;
+
+    /**
+     * 매일 새벽 6시에 미처리 raw_items 배치 변환
+     * - 모든 크롤러의 크롤링이 완료된 후 실행
+     * - 배치 크기: 100개씩 처리
+     */
+    @Scheduled(cron = "0 0 6 * * *") // 매일 새벽 6시
+    public void transformRawItemsDaily() {
+        log.info("🚀 [정기 스케줄] raw_items 배치 변환 시작");
+        
+        try {
+            int batchSize = 100;
+            int totalProcessed = 0;
+            int processed;
+            
+            // 미처리 데이터가 없을 때까지 반복 처리
+            do {
+                processed = batchTransformService.processBatch(batchSize);
+                totalProcessed += processed;
+                
+                if (processed > 0) {
+                    log.info("📦 배치 처리 완료: {}개 (누적: {}개)", processed, totalProcessed);
+                }
+                
+                // 다음 배치 처리 전 잠시 대기 (DB 부하 완화)
+                if (processed == batchSize) {
+                    Thread.sleep(1000); // 1초 대기
+                }
+            } while (processed == batchSize);
+            
+            log.info("✅ [정기 스케줄] raw_items 배치 변환 완료: 총 {}개 처리", totalProcessed);
+        } catch (Exception e) {
+            log.error("❌ [정기 스케줄] raw_items 배치 변환 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 매주 일요일 새벽 7시에 대규모 배치 변환
+     * - 주간 누적된 미처리 데이터 일괄 처리
+     * - 배치 크기: 200개씩 처리 (대량 처리)
+     */
+    @Scheduled(cron = "0 0 7 * * SUN") // 매주 일요일 새벽 7시
+    public void transformRawItemsWeekly() {
+        log.info("🚀 [정기 스케줄] raw_items 주간 대규모 배치 변환 시작");
+        
+        try {
+            int batchSize = 200;
+            int totalProcessed = 0;
+            int processed;
+            
+            // 미처리 데이터가 없을 때까지 반복 처리
+            do {
+                processed = batchTransformService.processBatch(batchSize);
+                totalProcessed += processed;
+                
+                if (processed > 0) {
+                    log.info("📦 대규모 배치 처리 완료: {}개 (누적: {}개)", processed, totalProcessed);
+                }
+                
+                // 다음 배치 처리 전 잠시 대기
+                if (processed == batchSize) {
+                    Thread.sleep(500); // 0.5초 대기
+                }
+            } while (processed == batchSize);
+            
+            log.info("✅ [정기 스케줄] raw_items 주간 대규모 배치 변환 완료: 총 {}개 처리", totalProcessed);
+        } catch (Exception e) {
+            log.error("❌ [정기 스케줄] raw_items 주간 대규모 배치 변환 실패: {}", e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION

## 🛰️ Issue Number 


## 🪐 작업 내용

### 네이버 시리즈 스케줄링 개선
- **신작 크롤링 추가**: 매일 새벽 2시 신작 웹소설 수집 (recentList.series)
  - 3페이지, 약 60개 신작 자동 수집
  - 빠르게 변하는 신작 정보를 매일 업데이트
- **완결작 스케줄 변경**: 화요일 → 일요일 새벽 3시로 변경
  - 50페이지, 약 1000개 완결작 주간 수집
  - 다른 크롤러와 시간대 분산

### Transform 자동화 배치 처리
- **TransformSchedulingService 신규 생성**: raw_items 자동 변환 스케줄러 추가
- **매일 새벽 6시**: 일일 배치 변환
  - 100개씩 배치 처리
  - 모든 크롤러 작업 완료 후 실행
  - 미처리 데이터가 없을 때까지 반복
- **일요일 새벽 7시**: 주간 대규모 배치 변환
  - 200개씩 배치 처리
  - 주간 누적 데이터 일괄 처리

### NaverSeriesCrawler 메서드 추가
- `crawlRecentNovels()`: 신작 목록 크롤링 전용 메서드
- `crawlCompletedNovels()`: 완결작 목록 크롤링 전용 메서드

### 문서 업데이트
- `scheduling-overview.md`: 전체 스케줄 타임라인 업데이트
- 새로운 Transform 스케줄러 상세 설명 추가

## 📚 공유 사항

### 중점 리뷰 포인트
1. **TransformSchedulingService 로직**: 
   - 배치 처리가 무한 루프에 빠지지 않는지 확인 (`processed == batchSize` 조건)
   - Thread.sleep() 사용이 적절한지 검토
2. **스케줄 시간대 충돌**: 
   - 02:00 - 네이버 시리즈, 네이버 웹툰 동시 실행 (crawlerTaskExecutor 스레드풀 사용)
   - 06:00/07:00 - Transform 작업이 다른 작업과 겹치지 않음 확인
3. **recentList.series URL**: 실제 페이지 구조가 categoryProductList와 동일한지 검증 필요

### 참고 사항
- crawlerTaskExecutor 스레드풀 설정
- Transform 배치 처리는 동기 방식 (비동기 필요 시 추후 변경 가능)
- 네이버 시리즈 월간 대규모 수집 스케줄은 제거됨 (주간 수집으로 통합)

