### PR TITLE
fix(deploy): Crawler 배포 실패 해결 - 디스크 공간 확보를 위한 긴급 조치

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,44 +283,59 @@ jobs:
             export AWS_REGION='${AWS_REGION}'
             export ECR_REGISTRY='${ECR_REGISTRY}'
 
-            # --- Aggressive disk space cleanup before deployment ---
+            # --- CRITICAL: Emergency disk space recovery for Crawler ---
             echo "=> Disk usage before cleanup:"
             df -h || true
             echo "=> Docker system usage before cleanup:"
             docker system df || true
             
-            # 1. Docker cleanup
-            echo "=> Cleaning Docker resources..."
-            docker system prune -af --volumes || sudo docker system prune -af --volumes || true
-            docker image prune -af || true
-            docker volume prune -f || true
+            # 0. Stop existing services first to release locks
+            echo "=> Stopping existing services..."
+            docker compose down --remove-orphans || true
+            
+            # 1. FORCE remove ALL Docker images (we'll pull fresh ones)
+            echo "=> FORCE removing ALL Docker images..."
+            docker rmi -f \$(docker images -aq) 2>/dev/null || true
+            
+            # 2. Aggressive Docker cleanup
+            echo "=> Deep cleaning Docker resources..."
+            sudo docker system prune -af --volumes || true
+            sudo rm -rf /var/lib/docker/overlay2/* || true
+            sudo rm -rf /var/lib/docker/tmp/* || true
             docker builder prune -af || true
             
-            # 2. Remove all stopped containers and dangling volumes
-            docker container prune -f || true
-            docker volume rm \$(docker volume ls -qf dangling=true) 2>/dev/null || true
+            # 3. Kill zombie processes
+            echo "=> Killing zombie processes..."
+            sudo pkill -9 -f defunct || true
             
-            # 3. APT cache cleanup
+            # 4. APT cache cleanup (force unlock)
             echo "=> Cleaning APT cache..."
+            sudo killall apt-get 2>/dev/null || true
+            sudo rm -f /var/lib/apt/lists/lock || true
+            sudo rm -f /var/cache/apt/archives/lock || true
+            sudo rm -f /var/lib/dpkg/lock* || true
             sudo apt-get clean || true
-            sudo apt-get autoclean || true
-            sudo apt-get autoremove -y || true
             sudo rm -rf /var/lib/apt/lists/* || true
+            sudo rm -rf /var/cache/apt/archives/* || true
             
-            # 4. Log files cleanup (older than 7 days)
-            echo "=> Cleaning old log files..."
-            sudo find /var/log -type f -name "*.log" -mtime +7 -delete || true
+            # 5. Log files cleanup (ALL .gz files, older logs)
+            echo "=> Cleaning ALL old logs..."
             sudo find /var/log -type f -name "*.gz" -delete || true
-            sudo journalctl --vacuum-time=7d || true
+            sudo find /var/log -type f -name "*.log" -mtime +3 -delete || true
+            sudo find /var/log -type f -size +10M -delete || true
+            sudo journalctl --vacuum-time=3d || true
+            sudo journalctl --vacuum-size=50M || true
             
-            # 5. Temporary files cleanup
+            # 6. Temporary files cleanup
             echo "=> Cleaning temporary files..."
             sudo rm -rf /tmp/* || true
             sudo rm -rf /var/tmp/* || true
+            sudo rm -rf ~/.cache/* || true
             
-            # 6. Remove old kernels (keep current + 1)
-            echo "=> Removing old kernels..."
-            sudo apt-get autoremove --purge -y || true
+            # 7. Remove crash dumps
+            echo "=> Removing crash dumps..."
+            sudo rm -rf /var/crash/* || true
+            sudo rm -rf /var/core/* || true
             
             echo "=> Disk usage after cleanup:"
             df -h || true
@@ -328,7 +343,7 @@ jobs:
             aws ecr get-login-password --region \${AWS_REGION} | docker login --username AWS --password-stdin \${ECR_REGISTRY}
             echo "✅ ECR login successful for Crawler."
 
-            docker compose down --remove-orphans || true
+            # Pull new image (old ones already deleted)
             docker pull \${CRAWLER_IMAGE_URI}
             docker compose up -d --remove-orphans
 


### PR DESCRIPTION
문제:
- Crawler 배포 중 'no space left on device' 에러
- cleanup 후에도 344MB만 확보되어 1.4GB 이미지 pull 불가
- 1961개 좀비 프로세스, APT lock 문제

해결:
1. 배포 전 기존 Docker 이미지 전체 강제 삭제 (공간 즉시 확보)
2. Docker overlay2, tmp 디렉토리 직접 정리
3. 좀비 프로세스 강제 종료
4. APT lock 강제 해제 및 캐시 완전 삭제
5. 로그 파일 공격적 삭제 (3일, 10MB+, journalctl 50MB)
6. Crash dump 삭제
7. 사용자 캐시 삭제

순서 변경:
- docker compose down  먼저 실행
- 모든 이미지 삭제  ECR login  새 이미지 pull

<!-- 
  Assignees : 자기 자신
  Reviewers : 팀원 중 한명 선택
-->

## 🛰️ Issue Number 
<!-- 이슈 번호를 작성해주세요. ex) #13 -->
<!-- issue도 함께 close 하고 싶다면 close #이슈번호 로 작성해주세요. -->
- #이슈번호
- close #이슈번호

## 🪐 작업 내용
<!-- 작업 내용에 대해 설명해주세요 -->
-
-

## 📚 공유 사항
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
<!-- 리뷰어가 알고 있어야 하는 내용이 있다면 적어주세요. -->