### PR TITLE
fix: Add WebDriver timeout settings to prevent zombie processes

### DIFF
--- a/-AOD-All-of-Dopamine-crawler/src/main/java/com/example/crawler/util/ChromeDriverProvider.java
+++ b/-AOD-All-of-Dopamine-crawler/src/main/java/com/example/crawler/util/ChromeDriverProvider.java
@@ -84,7 +84,17 @@ public class ChromeDriverProvider {
         options.setExperimentalOption("excludeSwitches", List.of("enable-automation"));
         options.setExperimentalOption("useAutomationExtension", false);
         
-        return new ChromeDriver(options);
+        ChromeDriver driver = new ChromeDriver(options);
+        
+        // 🚀 핵심: Timeout 설정 (좀비 프로세스 방지!)
+        // timeout 없이 driver.get() 호출 시 무한 대기 → quit() 도달 못 함 → 좀비 프로세스
+        driver.manage().timeouts().pageLoadTimeout(java.time.Duration.ofSeconds(30));
+        driver.manage().timeouts().scriptTimeout(java.time.Duration.ofSeconds(30));
+        driver.manage().timeouts().implicitlyWait(java.time.Duration.ofSeconds(10));
+        
+        log.debug("ChromeDriver 생성 완료 (timeout 설정: pageLoad=30s, script=30s, implicit=10s)");
+        
+        return driver;
     }
 
 }


### PR DESCRIPTION
ROOT CAUSE (from StackOverflow research):
- Without timeout settings, driver.get() can hang FOREVER
- If driver.get() hangs, it never returns  quit() never called
- Meanwhile, next scheduled task creates NEW WebDriver
- Old Chrome processes become orphaned  zombies

SOLUTION:
- pageLoadTimeout: 30 seconds (prevents infinite page load)
- scriptTimeout: 30 seconds (prevents infinite JS execution)
- implicitlyWait: 10 seconds (element wait timeout)

EXPECTED BEHAVIOR:
- driver.get() will throw TimeoutException after 30s
- TimeoutException triggers catch  forceCleanupDriver()
- quit() is guaranteed to be called
- No more zombie Chrome processes

VERIFIED:
- All Selenium code (NaverWebtoonSeleniumPageParser, SteamRankingFetcher) properly calls driver.quit() in finally blocks
- The issue was not missing quit() calls, but infinite hangs preventing quit()

Reference: https://stackoverflow.com/questions/70338612

<!-- 
  Assignees : 자기 자신
  Reviewers : 팀원 중 한명 선택
-->

## 🛰️ Issue Number 
<!-- 이슈 번호를 작성해주세요. ex) #13 -->
<!-- issue도 함께 close 하고 싶다면 close #이슈번호 로 작성해주세요. -->
- #이슈번호
- close #이슈번호

## 🪐 작업 내용
<!-- 작업 내용에 대해 설명해주세요 -->
-
-

## 📚 공유 사항
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
<!-- 리뷰어가 알고 있어야 하는 내용이 있다면 적어주세요. -->