### PR TITLE
fix: Add tini to Docker to reap zombie Chrome processes

### DIFF
--- a/-AOD-All-of-Dopamine-crawler/Dockerfile
+++ b/-AOD-All-of-Dopamine-crawler/Dockerfile
@@ -25,12 +25,13 @@ RUN ./gradlew :-AOD-All-of-Dopamine-crawler:bootJar -x test --no-daemon
 FROM eclipse-temurin:17-jre
 WORKDIR /app
 
-# Install Chrome and dependencies for Selenium
+# Install tini (zombie process reaper) + Chrome and dependencies
 RUN apt-get update && apt-get install -y \
     wget \
     gnupg \
     curl \
     unzip \
+    tini \
     # Chrome dependencies
     fonts-liberation \
     libasound2t64 \
@@ -80,8 +81,9 @@ EXPOSE 8081
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
   CMD curl -f http://localhost:8081/actuator/health || exit 1
 
-# Run application
-ENTRYPOINT ["java", \
+# Run application with tini to handle zombie processes
+# tini acts as PID 1 and properly reaps zombie Chrome processes
+ENTRYPOINT ["/usr/bin/tini", "--", "java", \
     "-Xms512m", \
     "-Xmx2048m", \
     "-XX:+HeapDumpOnOutOfMemoryError", \


### PR DESCRIPTION
ROOT CAUSE:
- Java process (PID 4377) runs as non-PID-1 in Docker container
- Chrome child processes become zombies when terminated
- Java doesn't call wait() on these children
- No init process exists to reap zombies  accumulation

SOLUTION:
- Install tini package in Dockerfile
- Use tini as ENTRYPOINT wrapper: /usr/bin/tini -- java ...
- tini acts as proper init (PID 1) and reaps all zombie processes

WHAT IS TINI:
- Tiny but valid init for containers
- Forwards signals to child processes
- Reaps zombie processes automatically
- Standard solution for Docker zombie issues

TESTING:
After deploy, verify with:
  ps aux | grep defunct  # Should show 0 zombies
  ps -fp 1               # Should show tini as PID 1

Reference: https://github.com/krallin/tini

