### PR TITLE
feat: Snap 패키지 제거로 7GB 디스크 공간 확보

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -284,13 +284,31 @@ jobs:
             export ECR_REGISTRY='${ECR_REGISTRY}'
 
             # --- CRITICAL: Emergency disk space recovery for Crawler ---
-            echo "=> Disk usage before cleanup:"
+            echo "==> Disk usage before cleanup:"
             df -h || true
-            echo "=> Docker system usage before cleanup:"
+            echo "==> Docker system usage before cleanup:"
             docker system df || true
             
-            # 0. Stop existing services first to release locks
-            echo "=> Stopping existing services..."
+            # 0. FIRST: Remove massive unnecessary snap packages (7GB!)
+            echo "==> REMOVING GUI SNAP PACKAGES (7GB recovery expected)..."
+            sudo snap remove gnome-46-2404 --purge 2>/dev/null || true
+            sudo snap remove gnome-42-2204 --purge 2>/dev/null || true
+            sudo snap remove mesa-2404 --purge 2>/dev/null || true
+            sudo snap remove chromium --purge 2>/dev/null || true
+            sudo snap remove gtk-common-themes --purge 2>/dev/null || true
+            sudo snap remove cups --purge 2>/dev/null || true
+            
+            # Remove old snap revisions (disabled versions)
+            echo "==> Removing old snap revisions..."
+            snap list --all | awk '/disabled/{print $1, $3}' | while read snapname revision; do
+                sudo snap remove "$snapname" --revision="$revision" 2>/dev/null || true
+            done
+            
+            echo "==> Snap cleanup complete. Current disk usage:"
+            df -h || true
+            
+            # 1. Stop existing services first to release locks
+            echo "==> Stopping existing services..."
             docker compose down --remove-orphans || true
             
             # 1. FORCE remove ALL Docker images (we'll pull fresh ones)


### PR DESCRIPTION
## 문제
- 계속 'no space left on device' 에러 발생
- 디스크 사용량 분석 결과: /snap 디렉토리가 7GB 차지
  - gnome-46-2404: 3.2GB (GUI 데스크톱 - 서버에 불필요)
  - mesa-2404: 1.2GB (GPU 드라이버 - 서버에 불필요)
  - chromium: 800MB (브라우저 - Docker에 이미 포함)
  - 기타 GUI 패키지들: 1.8GB

## 해결
CI/CD 크롤러 배포 스크립트에 snap 패키지 제거 추가:
- GUI snap 패키지들 강제 제거 (--purge)
- 오래된 snap revision 정리
- Docker 작업 전에 먼저 실행하여 공간 확보

## 예상 효과
- 여유 공간: 1.6GB  8.6GB (7GB 확보)
- Docker 이미지 pull 문제 완전 해결
- 향후 배포 시 안정적인 디스크 공간 유지
