### PR TITLE
 진짜 범인 발견: snapd cache 2.5GB 정리 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -289,8 +289,12 @@ jobs:
             echo "==> Docker system usage before cleanup:"
             docker system df || true
             
-            # 0. FIRST: Remove massive unnecessary snap packages (7GB!)
-            echo "==> REMOVING GUI SNAP PACKAGES (7GB recovery expected)..."
+            # 0. FIRST: Clean snapd cache (2.5GB!)
+            echo "==> CLEANING SNAPD CACHE (2.5GB expected)..."
+            sudo rm -rf /var/lib/snapd/cache/* || true
+            
+            # Remove unnecessary snap packages if any
+            echo "==> Removing unnecessary snap packages..."
             sudo snap remove gnome-46-2404 --purge 2>/dev/null || true
             sudo snap remove gnome-42-2204 --purge 2>/dev/null || true
             sudo snap remove mesa-2404 --purge 2>/dev/null || true
@@ -300,7 +304,7 @@ jobs:
             
             # Remove old snap revisions (disabled versions)
             echo "==> Removing old snap revisions..."
-            snap list --all | awk '/disabled/{print $1, $3}' | while read snapname revision; do
+            snap list --all 2>/dev/null | awk '/disabled/{print $1, $3}' | while read snapname revision; do
                 sudo snap remove "$snapname" --revision="$revision" 2>/dev/null || true
             done
             


### PR DESCRIPTION
## 문제 원인 발견
- snap 패키지들은 작았지만 /var/lib/snapd/cache가 2.5GB 차지
- 이것이 디스크 부족의 실제 원인

## 수정 사항
1. snapd cache 정리 추가: sudo rm -rf /var/lib/snapd/cache/*
2. awk syntax error 수정: snap list --all에 2>/dev/null 추가

## 예상 효과
- 2.5GB 즉시 확보
- 여유 공간: 1.6GB  4.1GB
- Docker 이미지 pull 문제 해결
