### PR TITLE
fix: 네이버 크롤링 job-queue 변환시 제목이 저장안되어 변환저장안되는 버그 수정

### DIFF
--- a/-AOD-All-of-Dopamine-crawler/src/main/java/com/example/crawler/contents/Webtoon/NaverWebtoon/NaverWebtoonCrawler.java
+++ b/-AOD-All-of-Dopamine-crawler/src/main/java/com/example/crawler/contents/Webtoon/NaverWebtoon/NaverWebtoonCrawler.java
@@ -330,12 +330,13 @@ public class NaverWebtoonCrawler {
      */
     private NaverWebtoonDTO mergeBasicAndDetailedInfo(NaverWebtoonDTO basicDTO, NaverWebtoonDTO detailedDTO) {
         return NaverWebtoonDTO.builder()
-                // 목록에서 수집한 정보 우선 사용
-                .title(basicDTO.getTitle())
+                // [수정] Job Queue 모드에서는 basicDTO가 비어있으므로 detailedDTO 우선 사용
+                .title(basicDTO.getTitle() != null ? basicDTO.getTitle() : detailedDTO.getTitle())
                 .author(basicDTO.getAuthor() != null ? basicDTO.getAuthor() : detailedDTO.getAuthor())
                 .imageUrl(basicDTO.getImageUrl() != null ? basicDTO.getImageUrl() : detailedDTO.getImageUrl())
                 .titleId(basicDTO.getTitleId())
-                .weekday(basicDTO.getWeekday())
+                .weekday(basicDTO.getWeekday() != null && !basicDTO.getWeekday().isEmpty() 
+                        ? basicDTO.getWeekday() : detailedDTO.getWeekday())
                 .status(basicDTO.getStatus() != null ? basicDTO.getStatus() : detailedDTO.getStatus())
                 .likeCount(basicDTO.getLikeCount() != null ? basicDTO.getLikeCount() : detailedDTO.getLikeCount())
                 .serviceType(


### PR DESCRIPTION
## 문제
- Job Queue로 웹툰 크롤링 시 title이 빈 문자열로 저장됨
- UpsertService가 master_title이 blank면 저장을 건너뛰어 webtoon_contents 비어있음 ## 원인
- NaverWebtoonCrawler.mergeBasicAndDetailedInfo()에서 basicDTO.title 우선 사용
- Job Queue 모드에서는 basicDTO가 titleId만 있는 빈 객체
- detailedDTO에서 파싱한 실제 제목을 사용하지 않음 ## 수정
- title, weekday 등 null 체크 후 detailedDTO 값 우선 사용

