### PR TITLE
Fix 109/steam sorting

### DIFF
--- a/-AOD-All-of-Dopamine-api/src/main/java/com/example/AOD/api/controller/WorkController.java
+++ b/-AOD-All-of-Dopamine-api/src/main/java/com/example/AOD/api/controller/WorkController.java
@@ -45,7 +45,8 @@ public class WorkController {
             }
         }
 
-        Sort sort = Sort.by(Sort.Direction.fromString(sortDirection), sortBy);
+        Sort sort = Sort.by(Sort.Direction.fromString(sortDirection), sortBy)
+                        .and(Sort.by(Sort.Direction.ASC, "contentId"));
         Pageable pageable = PageRequest.of(page, size, sort);
 
         PageResponse<WorkSummaryDTO> response = workApiService.getWorks(domainEnum, keyword, platforms, genres, pageable);

--- a/-AOD-All-of-Dopamine-api/src/main/java/com/example/AOD/api/service/WorkApiService.java
+++ b/-AOD-All-of-Dopamine-api/src/main/java/com/example/AOD/api/service/WorkApiService.java
@@ -259,7 +259,7 @@ public class WorkApiService {
                 .page(0).size(0).totalElements(0L).totalPages(0)
                 .first(true).last(true).build();
     }
-    
+
     /**
      * ⚠️ Deprecated: 기존 Watch Providers 기반 필터링 (복잡한 로직)
      * 새로운 platforms 컬럼 방식으로 대체됨
@@ -338,7 +338,9 @@ public class WorkApiService {
                 contentPage = contentRepository.searchByKeyword(keyword, pageable);
             }
         } else if (domain != null) {
-            contentPage = contentRepository.findByDomain(domain, pageable);
+            Pageable pageableWithoutSort = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+            LocalDate maxDate = LocalDate.now().plusYears(1);
+            contentPage = contentRepository.findByDomainOrderByReleaseDateDesc(domain.name(), maxDate, pageableWithoutSort);
         } else {
             contentPage = contentRepository.findAll(pageable);
         }
@@ -401,25 +403,32 @@ public class WorkApiService {
             
             switch (order.getProperty()) {
                 case "masterTitle":
-                    orderComparator = Comparator.comparing(Content::getMasterTitle, 
-                            Comparator.nullsLast(String::compareTo));
+                    if (order.getDirection() == Sort.Direction.DESC) {
+                        orderComparator = Comparator.comparing(Content::getMasterTitle,
+                                Comparator.nullsLast(Comparator.reverseOrder()));
+                    } else {
+                        orderComparator = Comparator.comparing(Content::getMasterTitle,
+                                Comparator.nullsLast(Comparator.naturalOrder()));
+                    }
                     break;
                 case "releaseDate":
-                    orderComparator = Comparator.comparing(Content::getReleaseDate,
-                            Comparator.nullsLast(LocalDate::compareTo));
+                    if (order.getDirection() == Sort.Direction.DESC) {
+                        orderComparator = Comparator.comparing(Content::getReleaseDate,
+                                Comparator.nullsLast(Comparator.reverseOrder()));
+                    } else {
+                        orderComparator = Comparator.comparing(Content::getReleaseDate,
+                                Comparator.nullsLast(Comparator.naturalOrder()));
+                    }
                     break;
                 default:
                     orderComparator = Comparator.comparing(Content::getContentId);
-            }
-            
-            if (order.getDirection() == Sort.Direction.DESC) {
-                orderComparator = orderComparator.reversed();
             }
             
             comparator = (comparator == null) ? orderComparator : comparator.thenComparing(orderComparator);
         }
         
         if (comparator != null) {
+            comparator = comparator.thenComparing(Content::getContentId);
             return contents.stream().sorted(comparator).collect(Collectors.toList());
         }
         
@@ -625,12 +634,13 @@ public class WorkApiService {
      */
     public PageResponse<WorkSummaryDTO> getUpcomingReleases(Domain domain, List<String> platforms, Pageable pageable) {
         LocalDate now = LocalDate.now();
+        LocalDate oneYearLater = now.plusYears(1);
         
         List<Content> allContent;
         if (domain != null) {
-            allContent = contentRepository.findUpcomingReleases(domain, now, Pageable.unpaged()).getContent();
+            allContent = contentRepository.findUpcomingReleases(domain, now, oneYearLater, Pageable.unpaged()).getContent();
         } else {
-            allContent = contentRepository.findUpcomingReleases(now, Pageable.unpaged()).getContent();
+            allContent = contentRepository.findUpcomingReleases(now, oneYearLater, Pageable.unpaged()).getContent();
         }
 
         // 플랫폼 필터링 - MOVIE/TV는 watchProviders, 나머지는 PlatformData

--- a/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/ContentRepository.java
+++ b/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/ContentRepository.java
@@ -18,12 +18,12 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     // 도메인별 페이징 조회
     Page<Content> findByDomain(Domain domain, Pageable pageable);
     
-    // 도메인별 페이징 조회 (NULLS LAST + Tie-breaker 보장)
-    @Query(value = "SELECT * FROM contents WHERE domain = :domain " +
+    // 도메인별 페이징 조회 (NULLS LAST + Tie-breaker 보장, 오늘 기준 1년 이내만 노출)
+    @Query(value = "SELECT * FROM contents WHERE domain = :domain AND (release_date IS NULL OR release_date <= :maxDate) " +
            "ORDER BY release_date DESC NULLS LAST, content_id ASC",
-           countQuery = "SELECT COUNT(*) FROM contents WHERE domain = :domain",
+           countQuery = "SELECT COUNT(*) FROM contents WHERE domain = :domain AND (release_date IS NULL OR release_date <= :maxDate)",
            nativeQuery = true)
-    Page<Content> findByDomainOrderByReleaseDateDesc(@Param("domain") String domain, Pageable pageable);
+    Page<Content> findByDomainOrderByReleaseDateDesc(@Param("domain") String domain, @Param("maxDate") LocalDate maxDate, Pageable pageable);
     
     // 검색을 위한 메서드
     @Query("SELECT c FROM Content c WHERE c.domain = :domain AND " +
@@ -56,17 +56,19 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     Page<Content> findRecentReleases(@Param("endDate") LocalDate endDate, 
                                      Pageable pageable);
     
-    // 특정 날짜 이후 출시 예정인 작품 (공개예정) - 도메인별
-    @Query("SELECT c FROM Content c WHERE c.domain = :domain AND c.releaseDate > :startDate " +
+    // 특정 날짜 이후 출시 예정인 작품 (공개예정) - 도메인별 (오늘 기준 1년 이내 상한선)
+    @Query("SELECT c FROM Content c WHERE c.domain = :domain AND c.releaseDate > :startDate AND c.releaseDate <= :endDate " +
            "ORDER BY c.releaseDate ASC")
-    Page<Content> findUpcomingReleases(@Param("domain") Domain domain, 
-                                       @Param("startDate") LocalDate startDate, 
+    Page<Content> findUpcomingReleases(@Param("domain") Domain domain,
+                                       @Param("startDate") LocalDate startDate,
+                                       @Param("endDate") LocalDate endDate,
                                        Pageable pageable);
     
-    // 특정 날짜 이후 출시 예정인 작품 (공개예정) - 전체 도메인
-    @Query("SELECT c FROM Content c WHERE c.releaseDate > :startDate " +
+    // 특정 날짜 이후 출시 예정인 작품 (공개예정) - 전체 도메인 (오늘 기준 1년 이내 상한선)
+    @Query("SELECT c FROM Content c WHERE c.releaseDate > :startDate AND c.releaseDate <= :endDate " +
            "ORDER BY c.releaseDate ASC")
-    Page<Content> findUpcomingReleases(@Param("startDate") LocalDate startDate, 
+    Page<Content> findUpcomingReleases(@Param("startDate") LocalDate startDate,
+                                       @Param("endDate") LocalDate endDate,
                                        Pageable pageable);
     
     // 특정 날짜 범위의 신작 조회 - 도메인별

--- a/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/ContentRepository.java
+++ b/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/ContentRepository.java
@@ -18,7 +18,7 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     // 도메인별 페이징 조회
     Page<Content> findByDomain(Domain domain, Pageable pageable);
     
-    // 도메인별 페이징 조회 (NULLS LAST + Tie-breaker 보장, 오늘 기준 1년 이내만 노출)
+       // 도메인별 페이징 조회 (NULLS LAST + Tie-breaker 보장, release_date가 :maxDate 이하인 콘텐츠만 노출)
     @Query(value = "SELECT * FROM contents WHERE domain = :domain AND (release_date IS NULL OR release_date <= :maxDate) " +
            "ORDER BY release_date DESC NULLS LAST, content_id ASC",
            countQuery = "SELECT COUNT(*) FROM contents WHERE domain = :domain AND (release_date IS NULL OR release_date <= :maxDate)",
@@ -58,7 +58,7 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     
     // 특정 날짜 이후 출시 예정인 작품 (공개예정) - 도메인별 (오늘 기준 1년 이내 상한선)
     @Query("SELECT c FROM Content c WHERE c.domain = :domain AND c.releaseDate > :startDate AND c.releaseDate <= :endDate " +
-           "ORDER BY c.releaseDate ASC")
+           "ORDER BY c.releaseDate ASC, c.contentId ASC")
     Page<Content> findUpcomingReleases(@Param("domain") Domain domain,
                                        @Param("startDate") LocalDate startDate,
                                        @Param("endDate") LocalDate endDate,
@@ -66,7 +66,7 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     
     // 특정 날짜 이후 출시 예정인 작품 (공개예정) - 전체 도메인 (오늘 기준 1년 이내 상한선)
     @Query("SELECT c FROM Content c WHERE c.releaseDate > :startDate AND c.releaseDate <= :endDate " +
-           "ORDER BY c.releaseDate ASC")
+           "ORDER BY c.releaseDate ASC, c.contentId ASC")
     Page<Content> findUpcomingReleases(@Param("startDate") LocalDate startDate,
                                        @Param("endDate") LocalDate endDate,
                                        Pageable pageable);

--- a/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/ContentRepository.java
+++ b/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/ContentRepository.java
@@ -18,6 +18,13 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     // 도메인별 페이징 조회
     Page<Content> findByDomain(Domain domain, Pageable pageable);
     
+    // 도메인별 페이징 조회 (NULLS LAST + Tie-breaker 보장)
+    @Query(value = "SELECT * FROM contents WHERE domain = :domain " +
+           "ORDER BY release_date DESC NULLS LAST, content_id ASC",
+           countQuery = "SELECT COUNT(*) FROM contents WHERE domain = :domain",
+           nativeQuery = true)
+    Page<Content> findByDomainOrderByReleaseDateDesc(@Param("domain") String domain, Pageable pageable);
+    
     // 검색을 위한 메서드
     @Query("SELECT c FROM Content c WHERE c.domain = :domain AND " +
            "(LOWER(c.masterTitle) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +

--- a/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/GameContentRepository.java
+++ b/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/GameContentRepository.java
@@ -18,7 +18,7 @@ public interface GameContentRepository extends JpaRepository<GameContent, Long> 
     @Query(value = "SELECT g.* FROM game_contents g " +
            "JOIN contents c ON g.content_id = c.content_id " +
            "WHERE g.genres @> CAST(:genres AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, g.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM game_contents g " +
                        "WHERE g.genres @> CAST(:genres AS text[])",
            nativeQuery = true)
@@ -31,7 +31,7 @@ public interface GameContentRepository extends JpaRepository<GameContent, Long> 
     @Query(value = "SELECT g.* FROM game_contents g " +
            "JOIN contents c ON g.content_id = c.content_id " +
            "WHERE g.platforms @> CAST(:platforms AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, g.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM game_contents g " +
                        "WHERE g.platforms @> CAST(:platforms AS text[])",
            nativeQuery = true)
@@ -44,7 +44,7 @@ public interface GameContentRepository extends JpaRepository<GameContent, Long> 
            "JOIN contents c ON g.content_id = c.content_id " +
            "WHERE g.genres @> CAST(:genres AS text[]) " +
            "AND g.platforms @> CAST(:platforms AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, g.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM game_contents g " +
                        "WHERE g.genres @> CAST(:genres AS text[]) " +
                        "AND g.platforms @> CAST(:platforms AS text[])",

--- a/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/MovieContentRepository.java
+++ b/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/MovieContentRepository.java
@@ -18,7 +18,7 @@ public interface MovieContentRepository extends JpaRepository<MovieContent, Long
     @Query(value = "SELECT m.* FROM movie_contents m " +
            "JOIN contents c ON m.content_id = c.content_id " +
            "WHERE m.genres @> CAST(:genres AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, m.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM movie_contents m " +
                        "WHERE m.genres @> CAST(:genres AS text[])",
            nativeQuery = true)
@@ -31,7 +31,7 @@ public interface MovieContentRepository extends JpaRepository<MovieContent, Long
     @Query(value = "SELECT m.* FROM movie_contents m " +
            "JOIN contents c ON m.content_id = c.content_id " +
            "WHERE m.platforms @> CAST(:platforms AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, m.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM movie_contents m " +
                        "WHERE m.platforms @> CAST(:platforms AS text[])",
            nativeQuery = true)
@@ -44,7 +44,7 @@ public interface MovieContentRepository extends JpaRepository<MovieContent, Long
            "JOIN contents c ON m.content_id = c.content_id " +
            "WHERE m.genres @> CAST(:genres AS text[]) " +
            "AND m.platforms @> CAST(:platforms AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, m.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM movie_contents m " +
                        "WHERE m.genres @> CAST(:genres AS text[]) " +
                        "AND m.platforms @> CAST(:platforms AS text[])",

--- a/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/TvContentRepository.java
+++ b/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/TvContentRepository.java
@@ -18,7 +18,7 @@ public interface TvContentRepository extends JpaRepository<TvContent, Long> {
     @Query(value = "SELECT t.* FROM tv_contents t " +
            "JOIN contents c ON t.content_id = c.content_id " +
            "WHERE t.genres @> CAST(:genres AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, t.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM tv_contents t " +
                        "WHERE t.genres @> CAST(:genres AS text[])",
            nativeQuery = true)
@@ -31,7 +31,7 @@ public interface TvContentRepository extends JpaRepository<TvContent, Long> {
     @Query(value = "SELECT t.* FROM tv_contents t " +
            "JOIN contents c ON t.content_id = c.content_id " +
            "WHERE t.platforms @> CAST(:platforms AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, t.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM tv_contents t " +
                        "WHERE t.platforms @> CAST(:platforms AS text[])",
            nativeQuery = true)
@@ -44,7 +44,7 @@ public interface TvContentRepository extends JpaRepository<TvContent, Long> {
            "JOIN contents c ON t.content_id = c.content_id " +
            "WHERE t.genres @> CAST(:genres AS text[]) " +
            "AND t.platforms @> CAST(:platforms AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, t.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM tv_contents t " +
                        "WHERE t.genres @> CAST(:genres AS text[]) " +
                        "AND t.platforms @> CAST(:platforms AS text[])",

--- a/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/WebnovelContentRepository.java
+++ b/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/WebnovelContentRepository.java
@@ -19,7 +19,7 @@ public interface WebnovelContentRepository extends JpaRepository<WebnovelContent
     @Query(value = "SELECT w.* FROM webnovel_contents w " +
            "JOIN contents c ON w.content_id = c.content_id " +
            "WHERE w.genres @> CAST(:genres AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, w.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM webnovel_contents w " +
                        "WHERE w.genres @> CAST(:genres AS text[])",
            nativeQuery = true)
@@ -32,7 +32,7 @@ public interface WebnovelContentRepository extends JpaRepository<WebnovelContent
     @Query(value = "SELECT w.* FROM webnovel_contents w " +
            "JOIN contents c ON w.content_id = c.content_id " +
            "WHERE w.platforms @> CAST(:platforms AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, w.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM webnovel_contents w " +
                        "WHERE w.platforms @> CAST(:platforms AS text[])",
            nativeQuery = true)
@@ -45,7 +45,7 @@ public interface WebnovelContentRepository extends JpaRepository<WebnovelContent
            "JOIN contents c ON w.content_id = c.content_id " +
            "WHERE w.genres @> CAST(:genres AS text[]) " +
            "AND w.platforms @> CAST(:platforms AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, w.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM webnovel_contents w " +
                        "WHERE w.genres @> CAST(:genres AS text[]) " +
                        "AND w.platforms @> CAST(:platforms AS text[])",

--- a/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/WebtoonContentRepository.java
+++ b/-AOD-All-of-Dopamine-shared/src/main/java/com/example/shared/repository/WebtoonContentRepository.java
@@ -18,7 +18,7 @@ public interface WebtoonContentRepository extends JpaRepository<WebtoonContent, 
     @Query(value = "SELECT w.* FROM webtoon_contents w " +
            "JOIN contents c ON w.content_id = c.content_id " +
            "WHERE w.genres @> CAST(:genres AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, w.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM webtoon_contents w " +
                        "WHERE w.genres @> CAST(:genres AS text[])",
            nativeQuery = true)
@@ -31,7 +31,7 @@ public interface WebtoonContentRepository extends JpaRepository<WebtoonContent, 
     @Query(value = "SELECT w.* FROM webtoon_contents w " +
            "JOIN contents c ON w.content_id = c.content_id " +
            "WHERE w.platforms @> CAST(:platforms AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, w.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM webtoon_contents w " +
                        "WHERE w.platforms @> CAST(:platforms AS text[])",
            nativeQuery = true)
@@ -44,7 +44,7 @@ public interface WebtoonContentRepository extends JpaRepository<WebtoonContent, 
            "JOIN contents c ON w.content_id = c.content_id " +
            "WHERE w.genres @> CAST(:genres AS text[]) " +
            "AND w.platforms @> CAST(:platforms AS text[]) " +
-           "ORDER BY c.release_date DESC NULLS LAST",
+           "ORDER BY c.release_date DESC NULLS LAST, w.content_id ASC",
            countQuery = "SELECT COUNT(*) FROM webtoon_contents w " +
                        "WHERE w.genres @> CAST(:genres AS text[]) " +
                        "AND w.platforms @> CAST(:platforms AS text[])",


### PR DESCRIPTION
<!-- 
  Assignees : 자기 자신
  Reviewers : 팀원 중 한명 선택
-->

## 🛰️ Issue Number 
<!-- 이슈 번호를 작성해주세요. ex) #13 -->
<!-- issue도 함께 close 하고 싶다면 close #이슈번호 로 작성해주세요. -->
- #109 
- close #109

## 🪐 작업 내용
<!-- 작업 내용에 대해 설명해주세요 -->
- 5개 도메인의 장르·플랫폼 필터 쿼리에  
  `content_id ASC` tie-breaker 추가 → 결정적(deterministic) 정렬 보장
- `ContentRepository`의 `findByDomainOrderByReleaseDateDesc` 신규 메서드 추가  
  (오늘 기준 1년 이내만 노출, tie-breaker 포함)
- `findUpcomingReleases` 쿼리에 `endDate` 상한선 파라미터 추가  
  → 비정상적인 미래 날짜 필터링

## 📚 공유 사항
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
<!-- 리뷰어가 알고 있어야 하는 내용이 있다면 적어주세요. -->