### PR TITLE
feat(steam): 리뷰 집계 요약을 attr.review_summary로 수집

### DIFF
--- a/-AOD-All-of-Dopamine-crawler/src/main/java/com/example/crawler/common/queue/executors/SteamGameExecutor.java
+++ b/-AOD-All-of-Dopamine-crawler/src/main/java/com/example/crawler/common/queue/executors/SteamGameExecutor.java
@@ -29,6 +29,6 @@ public class SteamGameExecutor implements JobExecutor {
 
     @Override
     public long getAverageExecutionTime() {
-        return 1000; // API 기반, 평균 1초
+        return 2000; // 게임당 API 2회 호출 (appdetails + appreviews 리뷰 집계) — 평균 2초
     }
 }

--- a/-AOD-All-of-Dopamine-crawler/src/main/java/com/example/crawler/contents/game/steam/SteamApiFetcher.java
+++ b/-AOD-All-of-Dopamine-crawler/src/main/java/com/example/crawler/contents/game/steam/SteamApiFetcher.java
@@ -29,6 +29,33 @@ public class SteamApiFetcher {
 
     private static final String APP_DETAILS_URL = "https://store.steampowered.com/api/appdetails?appids={appId}&l=korean";
 
+    // 리뷰 집계 요약만 조회 (num_per_page=0 = 본문 없이 query_summary만).
+    // language=all: 집계 수치가 언어 필터에 좌우되므로 품질점수 용도로는 전세계 집계를 쓴다.
+    private static final String REVIEW_SUMMARY_URL =
+            "https://store.steampowered.com/appreviews/{appId}?json=1&language=all&purchase_type=all&num_per_page=0";
+
+    /**
+     * 리뷰 집계 요약(query_summary)을 조회합니다.
+     * 실패해도 게임 수집 자체를 막지 않도록 null을 반환합니다.
+     *
+     * @return {review_score, review_score_desc, total_positive, total_negative, total_reviews} 또는 null
+     */
+    public Map<String, Object> fetchReviewSummary(Long appId) {
+        try {
+            rateLimiter.acquirePermit();
+            String response = restTemplate.getForObject(REVIEW_SUMMARY_URL, String.class, appId);
+            JsonNode summary = objectMapper.readTree(response).path("query_summary");
+            if (summary.isMissingNode()) return null;
+            Map<String, Object> result = objectMapper.convertValue(summary,
+                    new TypeReference<Map<String, Object>>() {});
+            result.remove("num_reviews");   // "이번 페이지 개수" — num_per_page=0이라 항상 0인 노이즈
+            return result;
+        } catch (Exception e) {
+            log.warn("Steam 리뷰 요약 조회 실패 appId={}: {}", appId, e.getMessage());
+            return null;
+        }
+    }
+
     /**
      * Steam에 등록된 *게임* 앱 목록을 페이지네이션으로 안정적으로 가져옵니다. (IStoreService V1 사용)
      * 

--- a/-AOD-All-of-Dopamine-crawler/src/main/java/com/example/crawler/contents/game/steam/SteamCrawlService.java
+++ b/-AOD-All-of-Dopamine-crawler/src/main/java/com/example/crawler/contents/game/steam/SteamCrawlService.java
@@ -92,6 +92,8 @@ public class SteamCrawlService {
 
                 if (gameDetails != null && "game".equals(gameDetails.get("type"))) {
                     Map<String, Object> processedDetails = payloadProcessor.process(gameDetails);
+                    Map<String, Object> reviewSummary = steamApiFetcher.fetchReviewSummary(appId);
+                    if (reviewSummary != null) processedDetails.put("review_summary", reviewSummary);
                     collectorService.saveRaw(
                             "Steam",
                             "GAME",
@@ -136,7 +138,9 @@ public class SteamCrawlService {
             
             String appName = (String) gameDetails.get("name");
             Map<String, Object> processedDetails = payloadProcessor.process(gameDetails);
-            
+            Map<String, Object> reviewSummary = steamApiFetcher.fetchReviewSummary(appId);
+            if (reviewSummary != null) processedDetails.put("review_summary", reviewSummary);
+
             collectorService.saveRaw(
                     "Steam",
                     "GAME",

--- a/-AOD-All-of-Dopamine-crawler/src/main/resources/rules/game/steam.yml
+++ b/-AOD-All-of-Dopamine-crawler/src/main/resources/rules/game/steam.yml
@@ -19,6 +19,7 @@ mappings:
   detailed_description:  attr.detailed_description
   categories:            attr.categories
   recommendations.total: attr.recommendation_count
+  review_summary:        attr.review_summary    # 리뷰 집계 {review_score, review_score_desc, total_positive, total_negative, total_reviews}
 
 defaults:
   attr.recommendation_count: 0

--- a/-AOD-All-of-Dopamine-crawler/src/test/java/com/example/crawler/common/queue/executors/SteamGameExecutorTest.java
+++ b/-AOD-All-of-Dopamine-crawler/src/test/java/com/example/crawler/common/queue/executors/SteamGameExecutorTest.java
@@ -1,0 +1,24 @@
+package com.example.crawler.common.queue.executors;
+
+import com.example.crawler.contents.game.steam.SteamCrawlService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class SteamGameExecutorTest {
+
+    private final SteamGameExecutor executor = new SteamGameExecutor(mock(SteamCrawlService.class));
+
+    @Test
+    void averageTimeReflectsTwoApiCallsPerGame() {
+        // 게임당 appdetails + appreviews(리뷰 집계) 2회 호출 → 평균 처리시간 2배
+        assertEquals(2000, executor.getAverageExecutionTime());
+    }
+
+    @Test
+    void recommendedBatchSizeShrinksAccordingly() {
+        // 5000ms 틱 / 2000ms = 배치 2개 (구 5개에서 축소 — rate limit 배려)
+        assertEquals(2, executor.getRecommendedBatchSize());
+    }
+}

--- a/-AOD-All-of-Dopamine-crawler/src/test/java/com/example/crawler/contents/game/steam/SteamApiFetcherTest.java
+++ b/-AOD-All-of-Dopamine-crawler/src/test/java/com/example/crawler/contents/game/steam/SteamApiFetcherTest.java
@@ -1,0 +1,62 @@
+package com.example.crawler.contents.game.steam;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class SteamApiFetcherTest {
+
+    private RestTemplate restTemplate;
+    private SteamRateLimiter rateLimiter;
+    private SteamApiFetcher fetcher;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        rateLimiter = mock(SteamRateLimiter.class);
+        fetcher = new SteamApiFetcher(restTemplate, new ObjectMapper(), rateLimiter);
+    }
+
+    @Test
+    void fetchReviewSummaryReturnsSummaryWithoutPageNoiseField() {
+        when(restTemplate.getForObject(anyString(), eq(String.class), eq(70L))).thenReturn("""
+                {"success":1,"query_summary":{
+                  "num_reviews":0,"review_score":9,"review_score_desc":"Overwhelmingly Positive",
+                  "total_positive":31288,"total_negative":604,"total_reviews":31892}}
+                """);
+
+        Map<String, Object> summary = fetcher.fetchReviewSummary(70L);
+
+        assertNotNull(summary);
+        assertEquals(9, summary.get("review_score"));
+        assertEquals(31892, summary.get("total_reviews"));
+        assertEquals("Overwhelmingly Positive", summary.get("review_score_desc"));
+        assertFalse(summary.containsKey("num_reviews"), "페이지 노이즈(num_reviews)는 제거되어야 함");
+        verify(rateLimiter).acquirePermit();
+    }
+
+    @Test
+    void fetchReviewSummaryReturnsNullWhenSummaryMissing() {
+        when(restTemplate.getForObject(anyString(), eq(String.class), eq(999L)))
+                .thenReturn("{\"success\":2}");
+
+        assertNull(fetcher.fetchReviewSummary(999L));
+    }
+
+    @Test
+    void fetchReviewSummaryReturnsNullOnHttpFailureInsteadOfThrowing() {
+        when(restTemplate.getForObject(anyString(), eq(String.class), eq(70L)))
+                .thenThrow(new RestClientException("timeout"));
+
+        assertNull(fetcher.fetchReviewSummary(70L), "요약 조회 실패가 수집을 막으면 안 됨");
+    }
+}

--- a/-AOD-All-of-Dopamine-crawler/src/test/java/com/example/crawler/contents/game/steam/SteamCrawlServiceTest.java
+++ b/-AOD-All-of-Dopamine-crawler/src/test/java/com/example/crawler/contents/game/steam/SteamCrawlServiceTest.java
@@ -1,0 +1,62 @@
+package com.example.crawler.contents.game.steam;
+
+import com.example.crawler.ingest.CollectorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class SteamCrawlServiceTest {
+
+    private SteamApiFetcher fetcher;
+    private CollectorService collectorService;
+    private SteamCrawlService service;
+
+    @BeforeEach
+    void setUp() {
+        fetcher = mock(SteamApiFetcher.class);
+        collectorService = mock(CollectorService.class);
+        service = new SteamCrawlService(fetcher, collectorService, new SteamPayloadProcessor());
+    }
+
+    private Map<String, Object> gameDetails() {
+        Map<String, Object> details = new HashMap<>();
+        details.put("type", "game");
+        details.put("name", "Half-Life");
+        return details;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void mergesReviewSummaryIntoSavedPayload() {
+        when(fetcher.fetchGameDetails(70L)).thenReturn(gameDetails());
+        Map<String, Object> summary = Map.of("review_score", 9, "total_reviews", 31892);
+        when(fetcher.fetchReviewSummary(70L)).thenReturn(summary);
+
+        assertTrue(service.collectGameByAppId(70L));
+
+        ArgumentCaptor<Map<String, Object>> payload = ArgumentCaptor.forClass(Map.class);
+        verify(collectorService).saveRaw(eq("Steam"), eq("GAME"), payload.capture(), eq("70"), anyString());
+        assertEquals(summary, payload.getValue().get("review_summary"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void savesWithoutReviewSummaryWhenUnavailable() {
+        when(fetcher.fetchGameDetails(70L)).thenReturn(gameDetails());
+        when(fetcher.fetchReviewSummary(70L)).thenReturn(null);
+
+        assertTrue(service.collectGameByAppId(70L));
+
+        ArgumentCaptor<Map<String, Object>> payload = ArgumentCaptor.forClass(Map.class);
+        verify(collectorService).saveRaw(eq("Steam"), eq("GAME"), payload.capture(), eq("70"), anyString());
+        assertFalse(payload.getValue().containsKey("review_summary"), "요약 실패 시 키 자체가 없어야 함");
+    }
+}

--- a/-AOD-All-of-Dopamine-crawler/src/test/java/com/example/crawler/ingest/RuleFilesTest.java
+++ b/-AOD-All-of-Dopamine-crawler/src/test/java/com/example/crawler/ingest/RuleFilesTest.java
@@ -34,7 +34,8 @@ class RuleFilesTest {
                 "developers", List.of("Valve"), "publishers", List.of("Valve"),
                 "platforms", Map.of("windows", true, "mac", false),
                 "genres", List.of("FPS"),
-                "recommendations", Map.of("total", 12345)), registry.resolve("GAME", "Steam"));
+                "recommendations", Map.of("total", 12345),
+                "review_summary", Map.of("review_score", 9, "total_reviews", 31892)), registry.resolve("GAME", "Steam"));
         assertEquals("Half-Life", d.content().getMasterTitle());
         assertEquals(List.of("FPS"), d.content().getGenres());
         GameContent g = (GameContent) d.domainEntity();
@@ -42,6 +43,8 @@ class RuleFilesTest {
         assertEquals(Map.of("windows", true, "mac", false), g.getOsPlatforms());
         assertEquals("70", d.platformData().getPlatformSpecificId());
         assertEquals(12345, d.platformData().getAttributes().get("recommendation_count"));
+        assertEquals(Map.of("review_score", 9, "total_reviews", 31892),
+                d.platformData().getAttributes().get("review_summary"));   // 리뷰 집계 JSONB 객체
         assertEquals(List.of("Steam"), d.content().getPlatforms());   // 2026-07 마스터로 승격
     }
 


### PR DESCRIPTION
## Summary

스팀 리뷰 집계(`query_summary`)를 게임별 `platform_data.attributes.review_summary`(JSONB 객체)로 수집합니다. AI 추천의 품질점수(bayesian R·v) 재료 확보 목적.

- **`SteamApiFetcher.fetchReviewSummary`**: `appreviews?num_per_page=0&language=all` — 리뷰 본문 없이 집계만(응답 수백 바이트). 실패 시 null 반환으로 게임 수집을 막지 않음. 페이지 노이즈 `num_reviews` 제거
- **`SteamCrawlService`**: 두 수집 경로(목록 배치·단건) 모두 payload에 `review_summary` 병합 (실패 시 키 생략)
- **`steam.yml`**: `review_summary: attr.review_summary` 한 줄 — 파이프라인 코드 무수정 (v4 attr.* 통과 규칙)
- **`SteamGameExecutor`**: 평균 처리시간 1000→2000ms — 게임당 API 2회 호출 반영, 배치 5→2로 축소 (rate limit 배려)

저장 형태: `{review_score, review_score_desc, total_positive, total_negative, total_reviews}` — 조회는 `attributes->'review_summary'->>'total_reviews'`

## 기존 데이터 반영

마이그레이션 불필요 — 재크롤 시 payload 해시 변경 → 자동 재큐잉 → psid-identity 병합이 attributes 갱신 (readable-ingest 재작성의 재수집 경로 활용).

## Test plan

- [x] TDD (RED 확인 후 구현): Fetcher 3 / CrawlService 2 / RuleFilesTest 골든 확장 / Executor 핀 2 — 신규 7개
- [x] ingest 전체 회귀 그린 (BUILD SUCCESSFUL)
- [ ] 배포 후 Steam 소량 재크롤 → `attributes.review_summary` 채워지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)